### PR TITLE
[FIX] clippy and warnings

### DIFF
--- a/velodyne-lidar/src/batcher.rs
+++ b/velodyne-lidar/src/batcher.rs
@@ -66,17 +66,20 @@ where
     where
         I: IntoIterator<Item = E>,
     {
-        itertools::unfold(Some((firings.into_iter(), self)), |state| {
-            if let Some((iter, conv)) = state {
-                Some(if let Some(firing) = iter.next() {
-                    conv.push_one(firing)
+        std::iter::from_fn({
+            let mut state = Some((firings.into_iter(), self));
+            move || {
+                if let Some((iter, conv)) = &mut state {
+                    Some(if let Some(firing) = iter.next() {
+                        conv.push_one(firing)
+                    } else {
+                        let output = conv.take();
+                        state = None;
+                        output
+                    })
                 } else {
-                    let output = conv.take();
-                    *state = None;
-                    output
-                })
-            } else {
-                None
+                    None
+                }
             }
         })
         .flatten()

--- a/velodyne-lidar/src/traits/azimuth_range.rs
+++ b/velodyne-lidar/src/traits/azimuth_range.rs
@@ -19,25 +19,25 @@ pub trait AzimuthRange {
     }
 }
 
-impl<'a> AzimuthRange for FiringBlockS16<'a> {
+impl AzimuthRange for FiringBlockS16<'_> {
     fn azimuth_range(&self) -> Range<Angle> {
         self.azimuth_range.clone()
     }
 }
 
-impl<'a> AzimuthRange for FiringBlockS32<'a> {
+impl AzimuthRange for FiringBlockS32<'_> {
     fn azimuth_range(&self) -> Range<Angle> {
         self.azimuth_range.clone()
     }
 }
 
-impl<'a> AzimuthRange for FiringBlockD16<'a> {
+impl AzimuthRange for FiringBlockD16<'_> {
     fn azimuth_range(&self) -> Range<Angle> {
         self.azimuth_range.clone()
     }
 }
 
-impl<'a> AzimuthRange for FiringBlockD32<'a> {
+impl AzimuthRange for FiringBlockD32<'_> {
     fn azimuth_range(&self) -> Range<Angle> {
         self.azimuth_range.clone()
     }

--- a/velodyne-lidar/src/types/firing_block.rs
+++ b/velodyne-lidar/src/types/firing_block.rs
@@ -29,7 +29,7 @@ pub struct FiringBlockS16<'a> {
     pub channels: ChannelArraySRef<'a, 16>,
 }
 
-impl<'a> FiringBlockS16<'a> {
+impl FiringBlockS16<'_> {
     pub fn to_firing_raw(&self) -> FiringRawS16 {
         FiringRawS16 {
             toh: self.toh,
@@ -43,7 +43,7 @@ impl<'a> FiringBlockS16<'a> {
     }
 }
 
-impl<'a> FiringLike for FiringBlockS16<'a> {
+impl FiringLike for FiringBlockS16<'_> {
     type Point<'p>
         = &'p Channel
     where
@@ -70,7 +70,7 @@ pub struct FiringBlockS32<'a> {
     pub channels: ChannelArraySRef<'a, 32>,
 }
 
-impl<'a> FiringBlockS32<'a> {
+impl FiringBlockS32<'_> {
     pub fn to_firing_raw(&self) -> FiringRawS32 {
         FiringRawS32 {
             toh: self.toh,
@@ -84,7 +84,7 @@ impl<'a> FiringBlockS32<'a> {
     }
 }
 
-impl<'a> FiringLike for FiringBlockS32<'a> {
+impl FiringLike for FiringBlockS32<'_> {
     type Point<'p>
         = &'p Channel
     where
@@ -167,7 +167,7 @@ impl<'a> FiringBlockD16<'a> {
     }
 }
 
-impl<'a> FiringLike for FiringBlockD16<'a> {
+impl FiringLike for FiringBlockD16<'_> {
     type Point<'p>
         = ChannelRefD<'p>
     where
@@ -252,7 +252,7 @@ impl<'a> FiringBlockD32<'a> {
     }
 }
 
-impl<'a> FiringLike for FiringBlockD32<'a> {
+impl FiringLike for FiringBlockD32<'_> {
     type Point<'p>
         = ChannelRefD<'p>
     where
@@ -276,7 +276,7 @@ impl<'a> FiringLike for FiringBlockD32<'a> {
 pub type FiringBlock<'a> =
     FormatKind<FiringBlockS16<'a>, FiringBlockS32<'a>, FiringBlockD16<'a>, FiringBlockD32<'a>>;
 
-impl<'a> FiringBlock<'a> {
+impl FiringBlock<'_> {
     pub fn to_firing_xyz(&self, beams: &Config) -> Result<FiringXyz> {
         let err = || format_err!("TODO");
 

--- a/velodyne-lidar/src/types/firing_raw.rs
+++ b/velodyne-lidar/src/types/firing_raw.rs
@@ -83,7 +83,7 @@ mod ref_kind {
     pub type FiringRawRef<'a> =
         FormatKind<&'a FiringRawS16, &'a FiringRawS32, &'a FiringRawD16, &'a FiringRawD32>;
 
-    impl<'a> FiringRawRef<'a> {
+    impl FiringRawRef<'_> {
         pub fn time(&self) -> Duration {
             match self {
                 FiringRawRef::Single16(me) => me.toh,

--- a/velodyne-lidar/src/types/firing_xyz.rs
+++ b/velodyne-lidar/src/types/firing_xyz.rs
@@ -99,7 +99,7 @@ mod ref_kind {
     pub type FiringXyzRef<'a> =
         FormatKind<&'a FiringXyzS16, &'a FiringXyzS32, &'a FiringXyzD16, &'a FiringXyzD32>;
 
-    impl<'a> FiringXyzRef<'a> {
+    impl FiringXyzRef<'_> {
         pub fn time(&self) -> Duration {
             match self {
                 FiringXyzRef::Single16(me) => me.toh,


### PR DESCRIPTION
itertools::unfold is deprecated and causes a warning
the rest of the fix is to make clippy happy